### PR TITLE
Refactor: Clean up frontend components and data flow

### DIFF
--- a/frontend/src/Components/PDFViewer/PDFViewer.tsx
+++ b/frontend/src/Components/PDFViewer/PDFViewer.tsx
@@ -8,15 +8,13 @@ pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/$
 
 interface PDFViewerProps {
   url: string;
-  onTextSelect?: (text: string) => void;
 }
 
-const PDFViewer: React.FC<PDFViewerProps> = ({ url, onTextSelect }) => {
+const PDFViewer: React.FC<PDFViewerProps> = ({ url }) => {
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [scale, setScale] = useState<number>(1.0);
   const [error, setError] = useState<string | null>(null);
-  const [selectedText, setSelectedText] = useState('');
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
   // Reset state when URL changes
@@ -24,7 +22,6 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ url, onTextSelect }) => {
     setError(null);
     setNumPages(0);
     setCurrentPage(1);
-    setSelectedText('');
   }, [url]);
 
   // Memoize the file prop
@@ -56,10 +53,9 @@ const PDFViewer: React.FC<PDFViewerProps> = ({ url, onTextSelect }) => {
     const selection = window.getSelection();
     if (selection) {
       const text = selection.toString().trim();
-      if (text && text !== selectedText) {
-        setSelectedText(text);
-        onTextSelect?.(text);
-      }
+      // If 'text' is not empty, it means something was selected.
+      // Future functionality could be added here if needed.
+      // For now, the function confirms selection but doesn't propagate it or store it.
     }
   };
 

--- a/frontend/src/pages/DocumentChat.tsx
+++ b/frontend/src/pages/DocumentChat.tsx
@@ -6,7 +6,6 @@ import PDFViewer from '../Components/PDFViewer/PDFViewer';
 import ChatBot from '../Components/ChatBot';
 import { documentService } from '../services/documentService';
 import { useAppSelector } from '../store/hooks';
-import { selectUserEmail } from '../store/slices/userSlice';
 
 interface DocumentDetails {
   presignedUrl: string;
@@ -17,8 +16,6 @@ const DocumentChat: React.FC = () => {
   const [documentDetails, setDocumentDetails] = useState<DocumentDetails | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedText, setSelectedText] = useState<string[]>([]);
-  const userEmail = useAppSelector(selectUserEmail);
 
   useEffect(() => {
     const fetchDocumentDetails = async () => {
@@ -48,10 +45,6 @@ const DocumentChat: React.FC = () => {
 
     fetchDocumentDetails();
   }, [s3Key]);
-
-  const handleTextSelect = (text: string) => {
-    setSelectedText(prev => [...prev, text]);
-  };
 
   const pdfViewerKey = documentDetails?.presignedUrl || 'no-url';
 
@@ -85,7 +78,6 @@ const DocumentChat: React.FC = () => {
                     <PDFViewer 
                       key={pdfViewerKey}
                       url={documentDetails.presignedUrl} 
-                      onTextSelect={handleTextSelect}
                     />
                   </div>
                 </div>
@@ -94,9 +86,8 @@ const DocumentChat: React.FC = () => {
 
             {/* Chat container */}
             <div className="flex-1 lg:w-1/3 lg:max-w-[400px] min-h-0 bg-gray-900/50 rounded-lg overflow-hidden order-2">
-              {userEmail && s3Key ? (
+              {s3Key ? (
                 <ChatBot 
-                  userEmail={userEmail}
                   documentS3Key={s3Key}
                 />
               ) : null}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,11 +3,8 @@ import Navbar from '../Components/Navbar';
 import Sidebar from '../Components/Sidebar';
 import UploadDoc from '../Components/UploadDoc';
 import { useAppSelector } from '../store/hooks';
-import { selectUserEmail } from '../store/slices/userSlice';
 
 const HomePage: React.FC = () => {
-  const userEmail = useAppSelector(selectUserEmail);
-  const [oldUser] = useState(false);
 
   return (
     <div className="flex flex-col min-h-screen bg-black">
@@ -19,14 +16,7 @@ const HomePage: React.FC = () => {
         </div>
 
         <div className="flex-1 p-2 sm:p-4 md:p-6 w-full">
-          {oldUser ? (
-            <div className="py-4 sm:py-8">
-              <h1 className="text-2xl sm:text-3xl font-bold text-purple-400">Welcome to BRAINTOK</h1>
-              <p className="mt-2 sm:mt-4 text-gray-300">Logged in as: {userEmail}</p>
-            </div>
-          ) : (
             <UploadDoc />
-          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit addresses several areas in the frontend to improve code clarity, modularity, and reduce prop drilling.

Key changes include:

1.  **HomePage.tsx**: Removed unused 'oldUser' state and associated conditional rendering, simplifying the component. Also removed the 'userEmail' variable which was no longer needed.

2.  **ChatBot.tsx**: Refactored to retrieve 'userEmail' directly from the Redux store instead of receiving it as a prop. This reduces prop drilling from parent components.

3.  **DocumentChat.tsx & PDFViewer.tsx**: Removed an unused text selection feature. This involved deleting the 'selectedText' state and 'handleTextSelect' function in DocumentChat.tsx, and removing the 'onTextSelect' prop and related state from PDFViewer.tsx.

4.  **DocumentChat.tsx**: Updated to no longer pass 'userEmail' to ChatBot.tsx, as ChatBot now sources this data from Redux. Consequently, the 'userEmail' variable and its import were removed from DocumentChat.tsx.

These changes contribute to a cleaner, more maintainable, and extensible frontend codebase.